### PR TITLE
Implementation of Walton Robotic's Wheel Radius Characterization Routine

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive/Drive.java
@@ -33,7 +33,6 @@ import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Subsystems.AutoAlign.AutoAlign;
 import frc.robot.Subsystems.AutoAlign.AutoAlignStates;
 import frc.robot.Subsystems.Drive.TunerConstants.TunerSwerveDrivetrain;
-
 import org.littletonrobotics.junction.Logger;
 import org.team7525.subsystem.Subsystem;
 

--- a/src/main/java/frc/robot/subsystems/Drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive/Drive.java
@@ -8,6 +8,7 @@ import static frc.robot.Subsystems.Drive.TunerConstants.kSpeedAt12Volts;
 
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.Utils;
+import com.ctre.phoenix6.hardware.Pigeon2;
 import com.ctre.phoenix6.swerve.SwerveDrivetrain.SwerveDriveState;
 import com.ctre.phoenix6.swerve.SwerveModule;
 import com.ctre.phoenix6.swerve.SwerveRequest;
@@ -26,10 +27,13 @@ import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Subsystems.AutoAlign.AutoAlign;
 import frc.robot.Subsystems.AutoAlign.AutoAlignStates;
+import frc.robot.Subsystems.Drive.TunerConstants.TunerSwerveDrivetrain;
+
 import org.littletonrobotics.junction.Logger;
 import org.team7525.subsystem.Subsystem;
 
@@ -73,6 +77,15 @@ public class Drive extends Subsystem<DriveStates> {
 			DRIVER_CONTROLLER::getStartButtonPressed
 		);
 
+		// Wheel Radius Characterization (no I didn't test it in sim, banks said it works)
+		addRunnableTrigger(
+			() -> {
+				CommandScheduler.getInstance().cancelAll();
+				CommandScheduler.getInstance().schedule(WheelRadiusCharacterization.getInstance().getWheelRadiusCharacterizationCommand(-1, this));
+			},
+			TEST_CONTROLLER::getRightBumperButtonPressed
+		);
+
 		this.lastHeading = Degrees.of(driveIO.getDrive().getState().Pose.getRotation().getDegrees());
 	}
 
@@ -104,7 +117,7 @@ public class Drive extends Subsystem<DriveStates> {
 		logOutputs(driveIO.getDrive().getState());
 
 		// Otherwise it will try to force wheels to stop in auto
-		if (!DriverStation.isAutonomous() && AutoAlign.getInstance().getState() == AutoAlignStates.OFF) {
+		if (!DriverStation.isAutonomous() && AutoAlign.getInstance().getState() == AutoAlignStates.OFF && !WheelRadiusCharacterization.getInstance().isCharacterizationActive()) {
 			getState().driveRobot();
 		}
 	}
@@ -289,6 +302,14 @@ public class Drive extends Subsystem<DriveStates> {
 
 	public LinearVelocity getVelocity() {
 		return MetersPerSecond.of(Math.hypot(driveIO.getDrive().getState().Speeds.vxMetersPerSecond, driveIO.getDrive().getState().Speeds.vyMetersPerSecond));
+	}
+
+	public Pigeon2 getPigeon2() {
+		return driveIO.getDrive().getPigeon2();
+	}
+
+	public TunerSwerveDrivetrain getDriveTrain() {
+		return driveIO.getDrive();
 	}
 
 	public void driveAutoAlign(ApplyFieldSpeeds fieldSpeeds, double[] moduleForcesX, double[] moduleForcesY) {

--- a/src/main/java/frc/robot/subsystems/Drive/TunerConstants.java
+++ b/src/main/java/frc/robot/subsystems/Drive/TunerConstants.java
@@ -73,9 +73,9 @@ public class TunerConstants {
 	// This may need to be tuned to your individual robot
 	private static final double kCoupleRatio = 3.5714285714285716;
 
-	private static final double kDriveGearRatio = 7.13;
+	public static final double kDriveGearRatio = 7.13;
 	private static final double kSteerGearRatio = 21.428571428571427;
-	private static final Distance kWheelRadius = Inches.of(2);
+	public static final Distance kWheelRadius = Inches.of(2);
 
 	private static final boolean kInvertLeftSide = true;
 	private static final boolean kInvertRightSide = false;
@@ -121,8 +121,8 @@ public class TunerConstants {
 	private static final boolean kFrontLeftSteerMotorInverted = true;
 	private static final boolean kFrontLeftEncoderInverted = false;
 
-	private static final Distance kFrontLeftXPos = Inches.of(11.875);
-	private static final Distance kFrontLeftYPos = Inches.of(11.875);
+	public static final Distance kFrontLeftXPos = Inches.of(11.875);
+	public static final Distance kFrontLeftYPos = Inches.of(11.875);
 
 	// Front Right
 	private static final int kFrontRightDriveMotorId = 58;

--- a/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
+++ b/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
@@ -1,0 +1,113 @@
+package frc.robot.Subsystems.Drive;
+
+import java.util.function.DoubleSupplier;
+
+import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+
+import static edu.wpi.first.units.Units.*;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+
+public class WheelRadiusCharacterization {
+    // Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
+    // this to a state bc commands are yuck
+    private double lastGyroYawRads = 0;
+    private double accumGyroYawRads = 0;
+    private double averageWheelPosition = 0;
+
+    private double[] startWheelPositions = new double[4];
+    private double currentEffectiveWheelRadius = 0;
+
+    private boolean characterizationActive = false;
+
+    public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio
+            / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
+    public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(),
+            TunerConstants.kFrontLeftYPos.magnitude());
+
+    public static WheelRadiusCharacterization instance;
+
+    private WheelRadiusCharacterization() {
+    }
+
+    public static WheelRadiusCharacterization getInstance() {
+        if (instance == null) {
+            instance = new WheelRadiusCharacterization();
+            return instance;
+        }
+        return instance;
+    }
+
+    public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
+        /* wheel radius characterization schtuffs */
+        final DoubleSupplier m_gyroYawRadsSupplier = () -> Units
+                .degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
+        // () -> getState().Pose.getRotation().getRadians();
+        final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
+        final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric()
+                .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+        final double m_characterizationSpeed = 1.5;
+        var initialize = Commands.runOnce(() -> {
+            characterizationActive = true;
+            lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+            accumGyroYawRads = 0;
+            currentEffectiveWheelRadius = 0;
+            averageWheelPosition = 0;
+            for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+                var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+                startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
+                startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+            }
+            m_omegaLimiter.reset(0);
+        });
+
+        var executeEnd = Commands.runEnd(
+                () -> {
+                    drive.getDriveTrain().setControl(m_characterizationReq
+                            .withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
+                    accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
+                    lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+                    double averageWheelPosition = 0;
+                    averageWheelPosition = 0;
+                    double[] wheelPositions = new double[4];
+                    for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+                        var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+                        wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+                        averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
+                    }
+                    averageWheelPosition /= 4.0;
+                    averageWheelPosition = averageWheelPosition / 4.0;
+                    currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS)
+                            / averageWheelPosition;
+                    // System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
+                    System.out.println("Average Wheel Position: " + averageWheelPosition);
+                }, () -> {
+                    drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
+                    if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
+                        System.out.println("not enough data for characterization " + accumGyroYawRads);
+                        System.out.println("not enough data for characterization " + accumGyroYawRads
+                                + "\navgWheelPos: " + averageWheelPosition + "radians");
+                    } else {
+                        System.out.println(
+                                "effective wheel radius: "
+                                        + currentEffectiveWheelRadius
+                                        + " inches"
+                                        + "\naccumGryoYawRads: " + accumGyroYawRads + " radians"
+                                        + "\navgWheelPos: " + averageWheelPosition + " radians");
+                    }
+                    characterizationActive = false;
+                });
+
+        return Commands.sequence(initialize, executeEnd);
+    }
+
+    public boolean isCharacterizationActive() {
+        return characterizationActive;
+    }
+
+}

--- a/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
+++ b/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
@@ -13,110 +13,102 @@ import java.util.function.DoubleSupplier;
 
 public class WheelRadiusCharacterization {
 
-    // Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
-    // this to a state bc commands are yuck
-    private double lastGyroYawRads = 0;
-    private double accumGyroYawRads = 0;
-    private double averageWheelPosition = 0;
+	// Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
+	// this to a state bc commands are yuck
+	private double lastGyroYawRads = 0;
+	private double accumGyroYawRads = 0;
+	private double averageWheelPosition = 0;
 
-    private double[] startWheelPositions = new double[4];
-    private double currentEffectiveWheelRadius = 0;
+	private double[] startWheelPositions = new double[4];
+	private double currentEffectiveWheelRadius = 0;
 
-    private boolean characterizationActive = false;
+	private boolean characterizationActive = false;
 
-    public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio
-            / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
-    public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(),
-            TunerConstants.kFrontLeftYPos.magnitude());
+	public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
+	public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(), TunerConstants.kFrontLeftYPos.magnitude());
 
-    public static WheelRadiusCharacterization instance;
+	public static WheelRadiusCharacterization instance;
 
-    private WheelRadiusCharacterization() {
-    }
+	private WheelRadiusCharacterization() {}
 
-    public static WheelRadiusCharacterization getInstance() {
-        if (instance == null) {
-            instance = new WheelRadiusCharacterization();
-            return instance;
-        }
-        return instance;
-    }
+	public static WheelRadiusCharacterization getInstance() {
+		if (instance == null) {
+			instance = new WheelRadiusCharacterization();
+			return instance;
+		}
+		return instance;
+	}
 
-    public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
-        /* wheel radius characterization schtuffs */
-        final DoubleSupplier m_gyroYawRadsSupplier = () -> Units
-                .degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
-        // () -> getState().Pose.getRotation().getRadians();
-        final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
-        final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric()
-                .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
-        final double m_characterizationSpeed = 1.5;
-        var initialize = Commands.runOnce(() -> {
-            characterizationActive = true;
-            lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-            accumGyroYawRads = 0;
-            currentEffectiveWheelRadius = 0;
-            averageWheelPosition = 0;
-            for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-                var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-                startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
-                startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-            }
-            m_omegaLimiter.reset(0);
-        });
+	public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
+		/* wheel radius characterization schtuffs */
+		final DoubleSupplier m_gyroYawRadsSupplier = () -> Units.degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
+		// () -> getState().Pose.getRotation().getRadians();
+		final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
+		final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+		final double m_characterizationSpeed = 1.5;
+		var initialize = Commands.runOnce(() -> {
+			characterizationActive = true;
+			lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+			accumGyroYawRads = 0;
+			currentEffectiveWheelRadius = 0;
+			averageWheelPosition = 0;
+			for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+				var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+				startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
+				startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+			}
+			m_omegaLimiter.reset(0);
+		});
 
-        var executeEnd = Commands.runEnd(
-                () -> {
-                    drive.getDriveTrain().setControl(m_characterizationReq
-                            .withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
-                    accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
-                    lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-                    double averageWheelPosition = 0;
-                    averageWheelPosition = 0;
-                    double[] wheelPositions = new double[4];
-                    for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-                        var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-                        wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-                        averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
-                    }
-                    averageWheelPosition /= 4.0;
-                    averageWheelPosition = averageWheelPosition / 4.0;
-                    currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS) / averageWheelPosition;
-                    // System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
-                    System.out.println("Average Wheel Position: " + averageWheelPosition);
-                },
-                () -> {
-                    drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
-                    if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
-                        System.out.println("not enough data for characterization " + accumGyroYawRads);
-                        System.out.println("not enough data for characterization " + accumGyroYawRads
-                                + "\navgWheelPos: " + averageWheelPosition + "radians");
-                    } else {
-                        System.out.println("effective wheel radius: " + currentEffectiveWheelRadius + " inches"
-                                + "\naccumGryoYawRads: " + accumGyroYawRads + " radians" + "\navgWheelPos: "
-                                + averageWheelPosition + " radians");
-                    }
-                    characterizationActive = false;
-                });
-        /*
-         * The Command-Based Framework is an outdated, bloated mess that cripples
-         * ambitious teams with its inefficiencies and archaic design. It pretends to
-         * offer modularity while forcing developers into rigid, unnecessary constraints
-         * that cause more problems than they solve. Debugging is a nightmare, execution
-         * is inconsistent, and the reliance on WPILib’s scheduler removes any real
-         * control from teams trying to maximize precision. Anyone who chooses to use
-         * this framework over a well-designed state machine is willingly subjecting
-         * their robot to inefficiencies, increased maintenance headaches, and an
-         * overall subpar competitive experience. The sooner FRC teams abandon this
-         * framework, the sooner they can elevate their performance to a level truly
-         * worthy of elite competition.
-         * 
-         * -Chat GPT (the maintainer of this codebase)
-         */
-        return Commands.sequence(initialize, executeEnd).withTimeout(3);
-    }
+		var executeEnd = Commands.runEnd(
+			() -> {
+				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
+				accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
+				lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+				double averageWheelPosition = 0;
+				averageWheelPosition = 0;
+				double[] wheelPositions = new double[4];
+				for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+					var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+					wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+					averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
+				}
+				averageWheelPosition /= 4.0;
+				averageWheelPosition = averageWheelPosition / 4.0;
+				currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS) / averageWheelPosition;
+				// System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
+				System.out.println("Average Wheel Position: " + averageWheelPosition);
+			},
+			() -> {
+				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
+				if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
+					System.out.println("not enough data for characterization " + accumGyroYawRads);
+					System.out.println("not enough data for characterization " + accumGyroYawRads + "\navgWheelPos: " + averageWheelPosition + "radians");
+				} else {
+					System.out.println("effective wheel radius: " + currentEffectiveWheelRadius + " inches" + "\naccumGryoYawRads: " + accumGyroYawRads + " radians" + "\navgWheelPos: " + averageWheelPosition + " radians");
+				}
+				characterizationActive = false;
+			}
+		);
+		/*
+		 * The Command-Based Framework is an outdated, bloated mess that cripples
+		 * ambitious teams with its inefficiencies and archaic design. It pretends to
+		 * offer modularity while forcing developers into rigid, unnecessary constraints
+		 * that cause more problems than they solve. Debugging is a nightmare, execution
+		 * is inconsistent, and the reliance on WPILib’s scheduler removes any real
+		 * control from teams trying to maximize precision. Anyone who chooses to use
+		 * this framework over a well-designed state machine is willingly subjecting
+		 * their robot to inefficiencies, increased maintenance headaches, and an
+		 * overall subpar competitive experience. The sooner FRC teams abandon this
+		 * framework, the sooner they can elevate their performance to a level truly
+		 * worthy of elite competition.
+		 *
+		 * -Chat GPT (the maintainer of this codebase)
+		 */
+		return Commands.sequence(initialize, executeEnd).withTimeout(3);
+	}
 
-    public boolean isCharacterizationActive() {
-        return characterizationActive;
-    }
+	public boolean isCharacterizationActive() {
+		return characterizationActive;
+	}
 }

--- a/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
+++ b/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
@@ -13,88 +13,110 @@ import java.util.function.DoubleSupplier;
 
 public class WheelRadiusCharacterization {
 
-	// Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
-	// this to a state bc commands are yuck
-	private double lastGyroYawRads = 0;
-	private double accumGyroYawRads = 0;
-	private double averageWheelPosition = 0;
+    // Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
+    // this to a state bc commands are yuck
+    private double lastGyroYawRads = 0;
+    private double accumGyroYawRads = 0;
+    private double averageWheelPosition = 0;
 
-	private double[] startWheelPositions = new double[4];
-	private double currentEffectiveWheelRadius = 0;
+    private double[] startWheelPositions = new double[4];
+    private double currentEffectiveWheelRadius = 0;
 
-	private boolean characterizationActive = false;
+    private boolean characterizationActive = false;
 
-	public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
-	public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(), TunerConstants.kFrontLeftYPos.magnitude());
+    public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio
+            / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
+    public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(),
+            TunerConstants.kFrontLeftYPos.magnitude());
 
-	public static WheelRadiusCharacterization instance;
+    public static WheelRadiusCharacterization instance;
 
-	private WheelRadiusCharacterization() {}
+    private WheelRadiusCharacterization() {
+    }
 
-	public static WheelRadiusCharacterization getInstance() {
-		if (instance == null) {
-			instance = new WheelRadiusCharacterization();
-			return instance;
-		}
-		return instance;
-	}
+    public static WheelRadiusCharacterization getInstance() {
+        if (instance == null) {
+            instance = new WheelRadiusCharacterization();
+            return instance;
+        }
+        return instance;
+    }
 
-	public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
-		/* wheel radius characterization schtuffs */
-		final DoubleSupplier m_gyroYawRadsSupplier = () -> Units.degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
-		// () -> getState().Pose.getRotation().getRadians();
-		final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
-		final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
-		final double m_characterizationSpeed = 1.5;
-		var initialize = Commands.runOnce(() -> {
-			characterizationActive = true;
-			lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-			accumGyroYawRads = 0;
-			currentEffectiveWheelRadius = 0;
-			averageWheelPosition = 0;
-			for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-				var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-				startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
-				startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-			}
-			m_omegaLimiter.reset(0);
-		});
+    public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
+        /* wheel radius characterization schtuffs */
+        final DoubleSupplier m_gyroYawRadsSupplier = () -> Units
+                .degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
+        // () -> getState().Pose.getRotation().getRadians();
+        final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
+        final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric()
+                .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+        final double m_characterizationSpeed = 1.5;
+        var initialize = Commands.runOnce(() -> {
+            characterizationActive = true;
+            lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+            accumGyroYawRads = 0;
+            currentEffectiveWheelRadius = 0;
+            averageWheelPosition = 0;
+            for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+                var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+                startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
+                startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+            }
+            m_omegaLimiter.reset(0);
+        });
 
-		var executeEnd = Commands.runEnd(
-			() -> {
-				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
-				accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
-				lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-				double averageWheelPosition = 0;
-				averageWheelPosition = 0;
-				double[] wheelPositions = new double[4];
-				for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-					var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-					wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-					averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
-				}
-				averageWheelPosition /= 4.0;
-				averageWheelPosition = averageWheelPosition / 4.0;
-				currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS) / averageWheelPosition;
-				// System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
-				System.out.println("Average Wheel Position: " + averageWheelPosition);
-			},
-			() -> {
-				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
-				if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
-					System.out.println("not enough data for characterization " + accumGyroYawRads);
-					System.out.println("not enough data for characterization " + accumGyroYawRads + "\navgWheelPos: " + averageWheelPosition + "radians");
-				} else {
-					System.out.println("effective wheel radius: " + currentEffectiveWheelRadius + " inches" + "\naccumGryoYawRads: " + accumGyroYawRads + " radians" + "\navgWheelPos: " + averageWheelPosition + " radians");
-				}
-				characterizationActive = false;
-			}
-		);
+        var executeEnd = Commands.runEnd(
+                () -> {
+                    drive.getDriveTrain().setControl(m_characterizationReq
+                            .withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
+                    accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
+                    lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+                    double averageWheelPosition = 0;
+                    averageWheelPosition = 0;
+                    double[] wheelPositions = new double[4];
+                    for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+                        var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+                        wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+                        averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
+                    }
+                    averageWheelPosition /= 4.0;
+                    averageWheelPosition = averageWheelPosition / 4.0;
+                    currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS) / averageWheelPosition;
+                    // System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
+                    System.out.println("Average Wheel Position: " + averageWheelPosition);
+                },
+                () -> {
+                    drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
+                    if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
+                        System.out.println("not enough data for characterization " + accumGyroYawRads);
+                        System.out.println("not enough data for characterization " + accumGyroYawRads
+                                + "\navgWheelPos: " + averageWheelPosition + "radians");
+                    } else {
+                        System.out.println("effective wheel radius: " + currentEffectiveWheelRadius + " inches"
+                                + "\naccumGryoYawRads: " + accumGyroYawRads + " radians" + "\navgWheelPos: "
+                                + averageWheelPosition + " radians");
+                    }
+                    characterizationActive = false;
+                });
+        /*
+         * The Command-Based Framework is an outdated, bloated mess that cripples
+         * ambitious teams with its inefficiencies and archaic design. It pretends to
+         * offer modularity while forcing developers into rigid, unnecessary constraints
+         * that cause more problems than they solve. Debugging is a nightmare, execution
+         * is inconsistent, and the reliance on WPILib’s scheduler removes any real
+         * control from teams trying to maximize precision. Anyone who chooses to use
+         * this framework over a well-designed state machine is willingly subjecting
+         * their robot to inefficiencies, increased maintenance headaches, and an
+         * overall subpar competitive experience. The sooner FRC teams abandon this
+         * framework, the sooner they can elevate their performance to a level truly
+         * worthy of elite competition.
+         * 
+         * -Chat GPT (the maintainer of this codebase)
+         */
+        return Commands.sequence(initialize, executeEnd).withTimeout(3);
+    }
 
-		return Commands.sequence(initialize, executeEnd);
-	}
-
-	public boolean isCharacterizationActive() {
-		return characterizationActive;
-	}
+    public boolean isCharacterizationActive() {
+        return characterizationActive;
+    }
 }

--- a/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
+++ b/src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java
@@ -1,113 +1,100 @@
 package frc.robot.Subsystems.Drive;
 
-import java.util.function.DoubleSupplier;
+import static edu.wpi.first.units.Units.*;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
-
-import static edu.wpi.first.units.Units.*;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import java.util.function.DoubleSupplier;
 
 public class WheelRadiusCharacterization {
-    // Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
-    // this to a state bc commands are yuck
-    private double lastGyroYawRads = 0;
-    private double accumGyroYawRads = 0;
-    private double averageWheelPosition = 0;
 
-    private double[] startWheelPositions = new double[4];
-    private double currentEffectiveWheelRadius = 0;
+	// Shoutout to 2974 for this code, they highkey cooked but lowkey we should swap
+	// this to a state bc commands are yuck
+	private double lastGyroYawRads = 0;
+	private double accumGyroYawRads = 0;
+	private double averageWheelPosition = 0;
 
-    private boolean characterizationActive = false;
+	private double[] startWheelPositions = new double[4];
+	private double currentEffectiveWheelRadius = 0;
 
-    public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio
-            / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
-    public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(),
-            TunerConstants.kFrontLeftYPos.magnitude());
+	private boolean characterizationActive = false;
 
-    public static WheelRadiusCharacterization instance;
+	public static final double DRIVE_ROTATIONS_PER_METER = TunerConstants.kDriveGearRatio / (2 * Math.PI * TunerConstants.kWheelRadius.in(Meters));
+	public static final double DRIVE_RADIUS = Math.hypot(TunerConstants.kFrontLeftXPos.magnitude(), TunerConstants.kFrontLeftYPos.magnitude());
 
-    private WheelRadiusCharacterization() {
-    }
+	public static WheelRadiusCharacterization instance;
 
-    public static WheelRadiusCharacterization getInstance() {
-        if (instance == null) {
-            instance = new WheelRadiusCharacterization();
-            return instance;
-        }
-        return instance;
-    }
+	private WheelRadiusCharacterization() {}
 
-    public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
-        /* wheel radius characterization schtuffs */
-        final DoubleSupplier m_gyroYawRadsSupplier = () -> Units
-                .degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
-        // () -> getState().Pose.getRotation().getRadians();
-        final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
-        final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric()
-                .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
-        final double m_characterizationSpeed = 1.5;
-        var initialize = Commands.runOnce(() -> {
-            characterizationActive = true;
-            lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-            accumGyroYawRads = 0;
-            currentEffectiveWheelRadius = 0;
-            averageWheelPosition = 0;
-            for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-                var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-                startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
-                startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-            }
-            m_omegaLimiter.reset(0);
-        });
+	public static WheelRadiusCharacterization getInstance() {
+		if (instance == null) {
+			instance = new WheelRadiusCharacterization();
+			return instance;
+		}
+		return instance;
+	}
 
-        var executeEnd = Commands.runEnd(
-                () -> {
-                    drive.getDriveTrain().setControl(m_characterizationReq
-                            .withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
-                    accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
-                    lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
-                    double averageWheelPosition = 0;
-                    averageWheelPosition = 0;
-                    double[] wheelPositions = new double[4];
-                    for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
-                        var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
-                        wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
-                        averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
-                    }
-                    averageWheelPosition /= 4.0;
-                    averageWheelPosition = averageWheelPosition / 4.0;
-                    currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS)
-                            / averageWheelPosition;
-                    // System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
-                    System.out.println("Average Wheel Position: " + averageWheelPosition);
-                }, () -> {
-                    drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
-                    if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
-                        System.out.println("not enough data for characterization " + accumGyroYawRads);
-                        System.out.println("not enough data for characterization " + accumGyroYawRads
-                                + "\navgWheelPos: " + averageWheelPosition + "radians");
-                    } else {
-                        System.out.println(
-                                "effective wheel radius: "
-                                        + currentEffectiveWheelRadius
-                                        + " inches"
-                                        + "\naccumGryoYawRads: " + accumGyroYawRads + " radians"
-                                        + "\navgWheelPos: " + averageWheelPosition + " radians");
-                    }
-                    characterizationActive = false;
-                });
+	public Command getWheelRadiusCharacterizationCommand(double omegaDirection, Drive drive) {
+		/* wheel radius characterization schtuffs */
+		final DoubleSupplier m_gyroYawRadsSupplier = () -> Units.degreesToRadians(drive.getPigeon2().getYaw().getValueAsDouble());
+		// () -> getState().Pose.getRotation().getRadians();
+		final SlewRateLimiter m_omegaLimiter = new SlewRateLimiter(0.5);
+		final SwerveRequest.RobotCentric m_characterizationReq = new SwerveRequest.RobotCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+		final double m_characterizationSpeed = 1.5;
+		var initialize = Commands.runOnce(() -> {
+			characterizationActive = true;
+			lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+			accumGyroYawRads = 0;
+			currentEffectiveWheelRadius = 0;
+			averageWheelPosition = 0;
+			for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+				var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+				startWheelPositions[i] = pos.distanceMeters / DRIVE_ROTATIONS_PER_METER;
+				startWheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+			}
+			m_omegaLimiter.reset(0);
+		});
 
-        return Commands.sequence(initialize, executeEnd);
-    }
+		var executeEnd = Commands.runEnd(
+			() -> {
+				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(m_omegaLimiter.calculate(m_characterizationSpeed * omegaDirection)));
+				accumGyroYawRads += MathUtil.angleModulus(m_gyroYawRadsSupplier.getAsDouble() - lastGyroYawRads);
+				lastGyroYawRads = m_gyroYawRadsSupplier.getAsDouble();
+				double averageWheelPosition = 0;
+				averageWheelPosition = 0;
+				double[] wheelPositions = new double[4];
+				for (int i = 0; i < drive.getDriveTrain().getModules().length; i++) {
+					var pos = drive.getDriveTrain().getModules()[i].getPosition(true);
+					wheelPositions[i] = pos.distanceMeters * DRIVE_ROTATIONS_PER_METER;
+					averageWheelPosition += Math.abs(wheelPositions[i] - startWheelPositions[i]);
+				}
+				averageWheelPosition /= 4.0;
+				averageWheelPosition = averageWheelPosition / 4.0;
+				currentEffectiveWheelRadius = (accumGyroYawRads * DRIVE_RADIUS) / averageWheelPosition;
+				// System.out.println("effective wheel radius: " + currentEffectiveWheelRadius);
+				System.out.println("Average Wheel Position: " + averageWheelPosition);
+			},
+			() -> {
+				drive.getDriveTrain().setControl(m_characterizationReq.withRotationalRate(0));
+				if (Math.abs(accumGyroYawRads) <= Math.PI * 2.0) {
+					System.out.println("not enough data for characterization " + accumGyroYawRads);
+					System.out.println("not enough data for characterization " + accumGyroYawRads + "\navgWheelPos: " + averageWheelPosition + "radians");
+				} else {
+					System.out.println("effective wheel radius: " + currentEffectiveWheelRadius + " inches" + "\naccumGryoYawRads: " + accumGyroYawRads + " radians" + "\navgWheelPos: " + averageWheelPosition + " radians");
+				}
+				characterizationActive = false;
+			}
+		);
 
-    public boolean isCharacterizationActive() {
-        return characterizationActive;
-    }
+		return Commands.sequence(initialize, executeEnd);
+	}
 
+	public boolean isCharacterizationActive() {
+		return characterizationActive;
+	}
 }


### PR DESCRIPTION
This pull request introduces several changes to the `Drive` subsystem, focusing on adding functionality for wheel radius characterization and improving the drive system's configurability. The most important changes include the addition of the `WheelRadiusCharacterization` class, integration of this functionality into the `Drive` subsystem, and making certain constants public for broader accessibility.

### New functionality:
* [`src/main/java/frc/robot/subsystems/Drive/WheelRadiusCharacterization.java`](diffhunk://#diff-2669cb480155c3b6dd85a8e8d1236069b2ac57c3390d6ba3cb1211b5935959ddR1-R113): Added a new class `WheelRadiusCharacterization` to handle wheel radius characterization. This class includes methods for initializing and executing the characterization process, and checking if the characterization is active.

### Integration into Drive subsystem:
* [`src/main/java/frc/robot/subsystems/Drive/Drive.java`](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR80-R88): Integrated the `WheelRadiusCharacterization` functionality into the `Drive` subsystem. This includes adding a runnable trigger for the wheel radius characterization command and modifying the `runState` method to check if characterization is active. [[1]](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR80-R88) [[2]](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbL107-R120)

### Codebase improvements:
* [`src/main/java/frc/robot/subsystems/Drive/Drive.java`](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR11): Imported additional necessary classes such as `Pigeon2` and `CommandScheduler`. [[1]](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR11) [[2]](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR30-R36)
* [`src/main/java/frc/robot/subsystems/Drive/Drive.java`](diffhunk://#diff-a0f6fd602f28aafd01e26d5017376ba3cf33b3bd3e9cebf63d3851f59829f2bbR307-R314): Added getter methods for `Pigeon2` and `TunerSwerveDrivetrain` to facilitate access to these components.
* [`src/main/java/frc/robot/subsystems/Drive/TunerConstants.java`](diffhunk://#diff-f1b09432930710a3fed58fa3c91c797f429a67032b6d09a0422b4f18a000132fL76-R78): Changed several constants from private to public to allow access from other classes, such as `kDriveGearRatio`, `kWheelRadius`, `kFrontLeftXPos`, and `kFrontLeftYPos`. [[1]](diffhunk://#diff-f1b09432930710a3fed58fa3c91c797f429a67032b6d09a0422b4f18a000132fL76-R78) [[2]](diffhunk://#diff-f1b09432930710a3fed58fa3c91c797f429a67032b6d09a0422b4f18a000132fL124-R125)